### PR TITLE
Binary queue implementation

### DIFF
--- a/lib/binary/queue.ex
+++ b/lib/binary/queue.ex
@@ -1,0 +1,99 @@
+defmodule Binary.Queue do
+  @moduledoc """
+  Queue binary data.
+
+  This queue implementation optimizes on the copying of binary data in memory.
+  Copying possibly occurs when binary data is taken out of the queue.
+  """
+
+  @type t :: %__MODULE__{size: non_neg_integer, data: :queue.t()}
+  defstruct size: 0, data: :queue.new()
+
+  @doc """
+  Create a new binary queue.
+  """
+  @spec new() :: t
+  def new() do
+    %__MODULE__{}
+  end
+
+  @spec push(binary, t) :: t
+  def push(data, queue) do
+    %__MODULE__{size: queue.size + byte_size(data), data: :queue.in(data, queue.data)}
+  end
+
+  @spec pull(t) :: {binary, t}
+  def pull(queue) do
+    pull(1, queue)
+  end
+
+  @spec pull(non_neg_integer, t) :: {binary, t}
+  def pull(amount, queue) do
+    pull(<<>>, amount, queue.size, queue.data)
+  end
+
+  defp pull(acc, 0, size, queue) do
+    {acc, %__MODULE__{size: size, data: queue}}
+  end
+
+  defp pull(acc, _amount, 0, queue) do
+    {acc, %__MODULE__{size: 0, data: queue}}
+  end
+
+  defp pull(acc, amount, size, queue) do
+    {element, popped_queue} = :queue.out(queue)
+    pull(acc, amount, size, popped_queue, element)
+  end
+
+  defp pull(acc, amount, _size, queue, :empty) do
+    pull(acc, amount, 0, queue)
+  end
+
+  defp pull(acc, amount, size, queue, {:value, data}) when amount == byte_size(data) do
+    pull(
+      Binary.append(acc, data),
+      0,
+      :erlang.max(0, size - byte_size(data)),
+      queue
+    )
+  end
+
+  defp pull(acc, amount, size, queue, {:value, data}) when amount > byte_size(data) do
+    data_size = byte_size(data)
+
+    pull(
+      Binary.append(acc, data),
+      amount - data_size,
+      :erlang.max(0, size - data_size),
+      queue
+    )
+  end
+
+  defp pull(acc, amount, size, queue, {:value, data}) when amount < byte_size(data) do
+    {first, rest} = Binary.split_at(data, amount)
+
+    pull(
+      Binary.append(acc, first),
+      0,
+      :erlang.max(0, size - amount),
+      :queue.in_r(rest, queue)
+    )
+  end
+
+  @spec len(%Binary.Queue{}) :: non_neg_integer
+  def len(queue) do
+    queue.size
+  end
+
+  @spec is_empty(%Binary.Queue{}) :: boolean
+  def is_empty(queue) do
+    queue.size == 0 && :queue.is_empty(queue.data)
+  end
+end
+
+## Implementation details
+
+## Skip thinking of Enumerable/Collectable for now
+## Configure chunk size
+## Repack binaries according the chunk size
+##   - when to do that: when taking out

--- a/lib/binary/queue.ex
+++ b/lib/binary/queue.ex
@@ -17,18 +17,18 @@ defmodule Binary.Queue do
     %__MODULE__{}
   end
 
-  @spec push(binary, t) :: t
-  def push(data, queue) do
+  @spec push(t, binary) :: t
+  def push(queue, data) do
     %__MODULE__{size: queue.size + byte_size(data), data: :queue.in(data, queue.data)}
   end
 
   @spec pull(t) :: {binary, t}
   def pull(queue) do
-    pull(1, queue)
+    pull(queue, 1)
   end
 
-  @spec pull(non_neg_integer, t) :: {binary, t}
-  def pull(amount, queue) do
+  @spec pull(t, non_neg_integer) :: {binary, t}
+  def pull(queue, amount) do
     pull(<<>>, amount, queue.size, queue.data)
   end
 

--- a/lib/binary/queue.ex
+++ b/lib/binary/queue.ex
@@ -1,32 +1,81 @@
 defmodule Binary.Queue do
   @moduledoc """
-  Queue binary data.
+  Queue for binary data.
 
-  This queue implementation optimizes on the copying of binary data in memory.
-  Copying possibly occurs when binary data is taken out of the queue.
+  It resembles a pipeline: data is pushed on one end and pulled from the other.
+  The order by which bytes are pushed in is the same by which they are pulled out.
+
+  Internally, this queue implementation optimizes on the amount of copying of
+  binary data in memory. Copying possibly occurs when binary data is pulled
+  from the queue.
+
+  ## Examples
+
+    iex> Binary.Queue.new() |>  Binary.Queue.push(<<5, 208, 224, 23, 85>>)
+    %Binary.Queue{data: {[<<5, 208, 224, 23, 85>>],[]}, size: 5}
+
+    iex> Binary.Queue.new() |>  Binary.Queue.push(<<5, 208, 224, 23, 85>>) |> Binary.Queue.pull(4)
+    {<<5, 208, 224, 23>> , %Binary.Queue{data: {[],["U"]}, size: 1}}
+
+    iex> Binary.Queue.new() |>  Binary.Queue.push(<<5, 208, 224, 23, 85>>) |> Binary.Queue.push(<<82, 203>>)
+    %Binary.Queue{data: {[<<82, 203>>],[<<5, 208, 224, 23, 85>>]}, size: 7}
+
   """
 
-  @type t :: %__MODULE__{size: non_neg_integer, data: :queue.t()}
+  @opaque t :: %__MODULE__{}
   defstruct size: 0, data: :queue.new()
 
   @doc """
-  Create a new binary queue.
+  Returns a new empty binary queue.
+
+  ## Examples
+
+    iex> Binary.Queue.new()
+    %Binary.Queue{data: {[],[]}, size: 0}
   """
   @spec new() :: t
   def new() do
     %__MODULE__{}
   end
 
+  @doc """
+  Push binary data on the queue. Returns a new queue containing the pushed binary data.
+
+  ## Examples
+
+    iex> Binary.Queue.push(Binary.Queue.new(), <<23, 75>>)
+    %Binary.Queue{data: {[<<23, 75>>],[]}, size: 2}
+  """
   @spec push(t, binary) :: t
   def push(queue, data) do
     %__MODULE__{size: queue.size + byte_size(data), data: :queue.in(data, queue.data)}
   end
 
+  @doc """
+  Pulls a single byte from the queue. Returns a tuple of the first byte and the new queue without that first byte.
+
+  ## Examples
+
+    iex> q = Binary.Queue.push(Binary.Queue.new(), <<23, 75>>)
+    %Binary.Queue{data: {[<<23, 75>>],[]}, size: 2}
+    iex> Binary.Queue.pull(q)
+    {<<23>>, %Binary.Queue{data: {[], ["K"]}, size: 1}}
+  """
   @spec pull(t) :: {binary, t}
   def pull(queue) do
     pull(queue, 1)
   end
 
+  @doc """
+  Pulls a number of bytes from the queue. Returns a tuple of the first byte and the new queue without that first byte.
+
+  ## Examples
+
+    iex> q = Binary.Queue.push(Binary.Queue.new(), <<23, 75, 17>>)
+    %Binary.Queue{data: {[<<23, 75, 17>>],[]}, size: 3}
+    iex> Binary.Queue.pull(q, 2)
+    {<<23, 75>>, %Binary.Queue{data: {[], [<<17>>]}, size: 1}}
+  """
   @spec pull(t, non_neg_integer) :: {binary, t}
   def pull(queue, amount) do
     pull(<<>>, amount, queue.size, queue.data)
@@ -80,20 +129,37 @@ defmodule Binary.Queue do
     )
   end
 
+  @doc """
+  Returns the amount of bytes on the queue
+
+  ## Examples
+
+    iex> q = Binary.Queue.push(Binary.Queue.new(), <<23, 75, 17>>)
+    %Binary.Queue{data: {[<<23, 75, 17>>],[]}, size: 3}
+    iex> Binary.Queue.len(q)
+    3
+  """
   @spec len(%Binary.Queue{}) :: non_neg_integer
   def len(queue) do
     queue.size
   end
 
+  @doc """
+  Returns the amount of bytes on the queue
+
+  ## Examples
+
+    iex> q = Binary.Queue.new()
+    %Binary.Queue{data: {[],[]}, size: 0}
+    iex> Binary.Queue.is_empty(q)
+    true
+    iex> q = Binary.Queue.push(q, <<23, 75, 17>>)
+    %Binary.Queue{data: {[<<23, 75, 17>>],[]}, size: 3}
+    iex> Binary.Queue.is_empty(q)
+    false
+  """
   @spec is_empty(%Binary.Queue{}) :: boolean
   def is_empty(queue) do
     queue.size == 0 && :queue.is_empty(queue.data)
   end
 end
-
-## Implementation details
-
-## Skip thinking of Enumerable/Collectable for now
-## Configure chunk size
-## Repack binaries according the chunk size
-##   - when to do that: when taking out

--- a/test/queue_test.exs
+++ b/test/queue_test.exs
@@ -11,52 +11,106 @@ defmodule Binary.QueueTest do
   end
 
   test "push a binary chunk" do
-    q1 = new()
-    q2 = push(<<0, 1, 2, 3, 4, 5, 6, 7, 8, 9>>, q1)
-    assert len(q2) == 10
-    assert is_empty(q2) == false
+    q =
+      new()
+      |> push(<<0, 1, 2, 3, 4, 5, 6, 7, 8, 9>>)
+
+    assert len(q) == 10
+    assert is_empty(q) == false
   end
 
   test "push two binary chunks" do
-    q1 = new()
-    q2 = push(<<0, 1, 2, 3, 4, 5, 6, 7, 8, 9>>, q1)
-    q3 = push(<<10, 11, 12, 13, 14>>, q2)
-    assert len(q3) == 15
-    assert is_empty(q3) == false
+    q =
+      new()
+      |> push(<<0, 1, 2, 3, 4, 5, 6, 7, 8, 9>>)
+      |> push(<<10, 11, 12, 13, 14>>)
+
+    assert len(q) == 15
+    assert is_empty(q) == false
   end
 
   test "pull shorter than first element length" do
-    q1 = new()
-    q2 = push(<<0, 1, 2, 3, 4, 5, 6, 7, 8, 9>>, q1)
-    {data, q3} = pull(5, q2)
-    assert len(q3) == 5
+    q =
+      new()
+      |> push(<<0, 1, 2, 3, 4, 5, 6, 7, 8, 9>>)
+
+    {data, q2} = pull(q, 5)
+    assert len(q2) == 5
     assert data == <<0, 1, 2, 3, 4>>
   end
 
   test "pull equal as first element length" do
-    q1 = new()
-    q2 = push(<<0, 1, 2, 3, 4, 5, 6, 7, 8, 9>>, q1)
-    {data, q3} = pull(10, q2)
-    assert len(q3) == 0
+    q =
+      new()
+      |> push(<<0, 1, 2, 3, 4, 5, 6, 7, 8, 9>>)
+
+    {data, q2} = pull(q, 10)
+    assert len(q2) == 0
     assert data == <<0, 1, 2, 3, 4, 5, 6, 7, 8, 9>>
   end
 
   test "pull larger as first element length without more data" do
-    q1 = new()
-    q2 = push(<<0, 1, 2, 3, 4, 5, 6, 7, 8, 9>>, q1)
-    {data, q3} = pull(15, q2)
-    assert len(q3) == 0
-    assert is_empty(q3) == true
+    q =
+      new()
+      |> push(<<0, 1, 2, 3, 4, 5, 6, 7, 8, 9>>)
+
+    {data, q2} = pull(q, 15)
+    assert len(q2) == 0
+    assert is_empty(q2) == true
     assert data == <<0, 1, 2, 3, 4, 5, 6, 7, 8, 9>>
   end
 
   test "pull larger as first element length with extra data" do
-    q1 = new()
-    q2 = push(<<0, 1, 2, 3, 4, 5, 6, 7, 8, 9>>, q1)
-    q3 = push(<<10, 11, 12, 13, 14>>, q2)
-    {data, q4} = pull(12, q3)
-    assert len(q4) == 3
-    assert is_empty(q4) == false
+    q =
+      new()
+      |> push(<<0, 1, 2, 3, 4, 5, 6, 7, 8, 9>>)
+      |> push(<<10, 11, 12, 13, 14>>)
+
+    {data, q2} = pull(q, 12)
+    assert len(q2) == 3
+    assert is_empty(q2) == false
     assert data == <<0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11>>
+  end
+
+  test "extensive test" do
+    q =
+      new()
+      |> push(<<1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14>>)
+      |> push(<<1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12>>)
+      |> push(<<1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17>>)
+      |> push(
+        <<1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23>>
+      )
+
+    assert len(q) == 66
+
+    {first_10, q_10} = pull(q, 10)
+    assert byte_size(first_10) == 10
+    assert len(q_10) == 56
+
+    {second_10, q_20} = pull(q_10, 10)
+    assert byte_size(second_10) == 10
+    assert len(q_20) == 46
+
+    {third_10, q_30} = pull(q_20, 10)
+    assert byte_size(third_10) == 10
+    assert len(q_30) == 36
+
+    {fourth_10, q_40} = pull(q_30, 10)
+    assert byte_size(fourth_10) == 10
+    assert len(q_40) == 26
+
+    {fifth_10, q_50} = pull(q_40, 10)
+    assert byte_size(fifth_10) == 10
+    assert len(q_50) == 16
+
+    {sixth_10, q_60} = pull(q_50, 10)
+    assert byte_size(sixth_10) == 10
+    assert len(q_60) == 6
+
+    {rest_6, q_66} = pull(q_60, 10)
+    assert byte_size(rest_6) == 6
+    assert len(q_66) == 0
+    assert is_empty(q_66)
   end
 end

--- a/test/queue_test.exs
+++ b/test/queue_test.exs
@@ -1,0 +1,62 @@
+defmodule Binary.QueueTest do
+  use ExUnit.Case
+  doctest Binary.Queue
+
+  import Binary.Queue
+
+  test "create" do
+    queue = new()
+    assert len(queue) == 0
+    assert is_empty(queue) == true
+  end
+
+  test "push a binary chunk" do
+    q1 = new()
+    q2 = push(<<0, 1, 2, 3, 4, 5, 6, 7, 8, 9>>, q1)
+    assert len(q2) == 10
+    assert is_empty(q2) == false
+  end
+
+  test "push two binary chunks" do
+    q1 = new()
+    q2 = push(<<0, 1, 2, 3, 4, 5, 6, 7, 8, 9>>, q1)
+    q3 = push(<<10, 11, 12, 13, 14>>, q2)
+    assert len(q3) == 15
+    assert is_empty(q3) == false
+  end
+
+  test "pull shorter than first element length" do
+    q1 = new()
+    q2 = push(<<0, 1, 2, 3, 4, 5, 6, 7, 8, 9>>, q1)
+    {data, q3} = pull(5, q2)
+    assert len(q3) == 5
+    assert data == <<0, 1, 2, 3, 4>>
+  end
+
+  test "pull equal as first element length" do
+    q1 = new()
+    q2 = push(<<0, 1, 2, 3, 4, 5, 6, 7, 8, 9>>, q1)
+    {data, q3} = pull(10, q2)
+    assert len(q3) == 0
+    assert data == <<0, 1, 2, 3, 4, 5, 6, 7, 8, 9>>
+  end
+
+  test "pull larger as first element length without more data" do
+    q1 = new()
+    q2 = push(<<0, 1, 2, 3, 4, 5, 6, 7, 8, 9>>, q1)
+    {data, q3} = pull(15, q2)
+    assert len(q3) == 0
+    assert is_empty(q3) == true
+    assert data == <<0, 1, 2, 3, 4, 5, 6, 7, 8, 9>>
+  end
+
+  test "pull larger as first element length with extra data" do
+    q1 = new()
+    q2 = push(<<0, 1, 2, 3, 4, 5, 6, 7, 8, 9>>, q1)
+    q3 = push(<<10, 11, 12, 13, 14>>, q2)
+    {data, q4} = pull(12, q3)
+    assert len(q4) == 3
+    assert is_empty(q4) == false
+    assert data == <<0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11>>
+  end
+end


### PR DESCRIPTION
This PR contains an implementation of a binary queue. The data structure uses an Erlang `:queue` internally to contain the `binary` data.

At push, the given `binary` data is added as a single element on the underlying Erlang `:queue`. At pull time, we will assemble a single binary taking just enough from the underlying queue.

This is a first implementation. I will optimize the implementation later if it would be possible to reduce the amount of binary copying.
